### PR TITLE
Fix panic if feedback_array.size == 0

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -326,11 +326,15 @@ impl<'a> PreeditInfo<'a> {
     /// Feedback information to each character of preedit text.
     /// Refer to [`InputFeedback`] for more details.
     pub fn feedback_array(&self) -> &[u32] {
-        unsafe {
-            std::slice::from_raw_parts(
-                self.inner.feedback_array.items,
-                self.inner.feedback_array.size as usize,
-            )
+        if self.inner.feedback_array.size == 0 {
+            &[]
+        } else {
+            unsafe {
+                std::slice::from_raw_parts(
+                    self.inner.feedback_array.items,
+                    self.inner.feedback_array.size as usize,
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
@wez 

This PR fixes the following panic if feedback_array.size == 0.
I encountered at running wezterm on X11 in WSLg.

related to: <https://github.com/wez/wezterm/pull/2056>

```
unsafe precondition(s) violated: slice::from_raw_parts requires the pointer to be aligned and non-null, and the total size of the slice not to exceed `isize::MAX`
```