### PR TITLE
Don't initialize IME again while it's already in progress

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -485,6 +485,7 @@ impl ImeClient {
             if let Some(logger) = LOGGER.lock().unwrap().as_mut() {
                 logger("try_open_ic timed out, retrying");
             }
+            unsafe { xcb_xim_close(self.im) };
         }
         self.ic_initializing = Some(now);
         let data: *mut ImeClient = self as _;


### PR DESCRIPTION
I've recently tried https://github.com/wez/wezterm/commit/30345b36d8a00fed347e4df5dadd83915a7693fb on Ubuntu 22.04 + X11 + ibus + ibus-hangul, and I've found that the IME isn't working most of the time.

After some debugging, I've discovered that:
1. In the release build the IME always doesn't work, and
2. In the debug build the IME works about 10% of the time, and
3. the IME initialization step(from `try_open_ic` to `create_ic_callback`) takes some time, up to 100ms, and
4. starting the IME initialization step again while it's already in progress ruins the internal state.

I've added a guard(with a 5-second timeout, so that it can deal with ime disconnects just in case) to `try_init_ic()`, and now the IME always works, even in the release build.

I believe updating wezterm with this change fixes the issue https://github.com/wez/wezterm/issues/5125